### PR TITLE
added rep-quant runewords for throwing weapons

### DIFF
--- a/btdiablo.mpq/data/global/excel/runes.txt
+++ b/btdiablo.mpq/data/global/excel/runes.txt
@@ -78,7 +78,8 @@ Runeword76	Love																																																0
 Runeword77	Loyalty																																																0
 Runeword78	Lust																																																0
 Runeword79	Madness																																																0
-Runeword81	Malice	1		109	mele									IthElEth	r06	r01	r05				openwounds		100	100	dmg-ac		-100	-100	noheal		1	1	dmg%		33	33	rep-dur	25			regen		-5	-5	lifesteal		7	7	0
+Runeword81	Malice	1		109	mele						thro			IthElEth	r06	r01	r05				openwounds		100	100	dmg-ac		-100	-100	noheal		1	1	dmg%		33	33	rep-dur	25			regen		-5	-5	lifesteal		7	7	0
+Runeword81	Malice	1		109	thro									IthElEth	r06	r01	r05				openwounds		100	100	dmg-ac		-100	-100	noheal		1	1	dmg%		33	33	rep-quant	25			regen		-5	-5	lifesteal		7	7	0
 Runeword82	Melody	1		109	miss									ShaelKoNef	r13	r18	r04				dmg%		50	50	skilltab	0	3	3	skill	9	3	3	skill	13	3	3	skill	17	3	3	dmg-undead		300	300					0
 Runeword83	Memory	1		109	staf									LumIoSolEth	r17	r16	r12	r05			mana%		20	20	red-mag		7	7	ac%		50	50	cast2		33	33	sor		3	3	skill	58	3	3	skill	42	2	2	0
 Runeword84	Mist	1	1	D2R Ladder 1	miss									ChamShaelGulThulIth	r32	r13	r25	r10	r06		allskills		3	3	dmg%		325	375	aura	Concentration	8	12	pierce		100	100	vit		24	24	res-all		40	40					0
@@ -131,12 +132,14 @@ Runeword130	Spirit	1		Previously Ladder Only	shld									MalThulOrtPul	r23	r10	
 Runeword131	Splendor	1		110	shld									EthLum	r05	r17					light		3	3	gold%		50	50	mag%		20	20	ac%		60	100	block2		20	20	cast2		20	20	allskills		1	1	0
 Runeword132	Starlight																																																0
 Runeword133	Stealth	1		109	tors									TalEth	r07	r05					red-mag		3	3	dex		6	6	stam		15	15	move2		25	25	cast2		25	25	balance2		25	25					0
-Runeword134	Steel	1		109	mele									TirEl	r03	r01					swing2		25	25	dmg		3	3	openwounds		50	50	dmg%		20	20	crush		5	5	rep-dur	25							0
+Runeword134	Steel	1		109	mele						thro			TirEl	r03	r01					swing2		25	25	dmg		3	3	openwounds		50	50	dmg%		20	20	crush		5	5	rep-dur	25							0
+Runeword134	Steel	1		109	thro									TirEl	r03	r01					swing2		25	25	dmg		3	3	openwounds		50	50	dmg%		20	20	crush		5	5	rep-quant	25							0
 Runeword135	Still Water																																																0
 Runeword136	Sting																																																0
 Runeword137	Stone	1		110	tors									ShaelUmPulLum	r13	r22	r21	r17			ac%		220	260	charged	Clay Golem	16	16	ac-miss		300	300	charged	Molten Boulder	80	16	str		16	16	vit		16	16	balance2		40	40	0
 Runeword138	Storm																																																0
-Runeword139	Strength	1		109	mele									AmnTir	r11	r03					str		20	20	dmg%		90	110	vit		10	10	crush		25	25	rep-dur	25											0
+Runeword139	Strength	1		109	mele						thro			AmnTir	r11	r03					str		20	20	dmg%		90	110	vit		10	10	crush		25	25	rep-dur	25											0
+Runeword139	Strength	1		109	thro									AmnTir	r11	r03					str		20	20	dmg%		90	110	vit		10	10	crush		25	25	rep-quant	25											0
 Runeword140	Tempest																																																0
 Runeword141	Temptation																																																0
 Runeword142	Terror																																																0


### PR DESCRIPTION
malice, steel, and strength all fit in throwing weapons, and have `rep-dur` (repair durability) mods, which don't work in throwing weapons

this patch duplicates those 3 runewords into:
- a non-throwing version (`thro` in `etype1` column)
- a throwing version (`thro` in itype1, `rep-quant` instead of `rep-dur`)

i tried just adding `rep-quant` to the existing runewords, but having both `rep-quant` and `rep-dur` doesn't work, for some reason